### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>"…

### DIFF
--- a/library/src/main/java/com/meg7/widget/BaseImageView.java
+++ b/library/src/main/java/com/meg7/widget/BaseImageView.java
@@ -89,7 +89,7 @@ public abstract class BaseImageView extends ImageView {
 //                        mPaint.setShader(mBitmapShader);
                         bitmapCanvas.drawBitmap(mMaskBitmap, 0.0f, 0.0f, mPaint);
 
-                        mWeakBitmap = new WeakReference<Bitmap>(bitmap);
+                        mWeakBitmap = new WeakReference<>(bitmap);
                     }
                 }
 

--- a/library/src/main/java/com/svgandroid/SVGParser.java
+++ b/library/src/main/java/com/svgandroid/SVGParser.java
@@ -220,7 +220,7 @@ public class SVGParser {
         //Util.debug("Parsing numbers from: '" + s + "'");
         int n = s.length();
         int p = 0;
-        ArrayList<Float> numbers = new ArrayList<Float>();
+        ArrayList<Float> numbers = new ArrayList<>();
         boolean skipChar = false;
         for (int i = 1; i < n; i++) {
             if (skipChar) {
@@ -483,8 +483,8 @@ public class SVGParser {
         boolean isLinear;
         float x1, y1, x2, y2;
         float x, y, radius;
-        ArrayList<Float> positions = new ArrayList<Float>();
-        ArrayList<Integer> colors = new ArrayList<Integer>();
+        ArrayList<Float> positions = new ArrayList<>();
+        ArrayList<Integer> colors = new ArrayList<>();
         Matrix matrix = null;
 
         public Gradient createChild(Gradient g) {
@@ -516,7 +516,7 @@ public class SVGParser {
     }
 
     private static class StyleSet {
-        HashMap<String, String> styleMap = new HashMap<String, String>();
+        HashMap<String, String> styleMap = new HashMap<>();
 
         private StyleSet(String string) {
             String[] styles = string.split(";");
@@ -616,8 +616,8 @@ public class SVGParser {
 
         boolean pushed = false;
 
-        HashMap<String, Shader> gradientMap = new HashMap<String, Shader>();
-        HashMap<String, Gradient> gradientRefMap = new HashMap<String, Gradient>();
+        HashMap<String, Shader> gradientMap = new HashMap<>();
+        HashMap<String, Gradient> gradientRefMap = new HashMap<>();
         Gradient gradient = null;
 
         private SVGHandler(Picture picture) {

--- a/samples/src/main/java/com/meg7/samples/SamplesActivity.java
+++ b/samples/src/main/java/com/meg7/samples/SamplesActivity.java
@@ -26,7 +26,7 @@ public class SamplesActivity extends Activity {
     }
 
     private class SvgImagesAdapter extends BaseAdapter {
-        private List<Integer> mSvgRawResourceIds = new ArrayList<Integer>();
+        private List<Integer> mSvgRawResourceIds = new ArrayList<>();
 
         private Context mContext;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
